### PR TITLE
fix spree_nav_cache_key change every time bug

### DIFF
--- a/app/helpers/spree/navigation_helper.rb
+++ b/app/helpers/spree/navigation_helper.rb
@@ -20,7 +20,7 @@ module Spree
       DEPRECATION
 
       @spree_nav_cache_key = begin
-                               keys = base_cache_key + [current_store, spree_navigation_data_cache_key, ::Spree::Config[:logo], stores&.cache_key_with_version, section]
+                               keys = base_cache_key + [current_store.inspect, spree_navigation_data_cache_key, ::Spree::Config[:logo], stores&.cache_key_with_version, section]
                                Digest::MD5.hexdigest(keys.join('-'))
                              end
     end

--- a/app/helpers/spree/navigation_helper.rb
+++ b/app/helpers/spree/navigation_helper.rb
@@ -20,7 +20,7 @@ module Spree
       DEPRECATION
 
       @spree_nav_cache_key = begin
-                               keys = base_cache_key + [current_store.inspect, spree_navigation_data_cache_key, ::Spree::Config[:logo], stores&.cache_key_with_version, section]
+                               keys = base_cache_key + [current_store.updated_at, spree_navigation_data_cache_key, ::Spree::Config[:logo], stores&.cache_key_with_version, section]
                                Digest::MD5.hexdigest(keys.join('-'))
                              end
     end


### PR DESCRIPTION
current_store is an object, and it is an instance of Spree::Store. current_store.to_s return Spree::Store and an encoding of the object id. The object id changes in every request, so does the cache key.
Every field and attachment of store changes, it will update current store's updated_at. So current_store.updated_at can be used as cache key.